### PR TITLE
fix permissions in Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,14 @@ ENV RESTYABOARD_VERSION=v0.6.2 \
 # deploy app
 RUN curl -L -s -o /tmp/restyaboard.zip https://github.com/RestyaPlatform/board/releases/download/${RESTYABOARD_VERSION}/board-${RESTYABOARD_VERSION}.zip && \
     unzip /tmp/restyaboard.zip -d ${ROOT_DIR} && \
-    rm /tmp/restyaboard.zip
+    rm /tmp/restyaboard.zip && \
+    chown -R www-data:www-data ${ROOT_DIR}
 
 # install apps
 ADD scripts/install_apps.sh /tmp/
 RUN chmod +x /tmp/install_apps.sh
-RUN . /tmp/install_apps.sh
+RUN . /tmp/install_apps.sh && \
+    chown -R www-data:www-data ${ROOT_DIR}
 
 # configure app
 WORKDIR ${ROOT_DIR}
@@ -53,9 +55,7 @@ RUN rm /etc/nginx/sites-enabled/default && \
     cp restyaboard.conf ${CONF_FILE} && \
     sed -i "s/server_name.*$/server_name \"localhost\";/" ${CONF_FILE} && \
 	sed -i "s|listen 80.*$|listen 80;|" ${CONF_FILE} && \
-    sed -i "s|root.*html|root ${ROOT_DIR}|" ${CONF_FILE} && \
-    chown -cR www-data:www-data . && \
-    chmod -R 777 .
+    sed -i "s|root.*html|root ${ROOT_DIR}|" ${CONF_FILE}
 
 # cleanup
 RUN apt-get autoremove -y --purge && \


### PR DESCRIPTION
this works around a bug in aufs used by the Ubuntu host system that
prevents later layers from giving broader permissions than previous
ones. Directories created in a RUN layer also need to chown them.

See https://github.com/moby/moby/issues/1295#issuecomment-269058662